### PR TITLE
Adding 2 example tests for the pytest lesson.

### DIFF
--- a/mdgeom/tests/test_info.py
+++ b/mdgeom/tests/test_info.py
@@ -41,6 +41,33 @@ def test_extract_ugmx():
         assert udata[key] == pytest.approx(reference[key])
 
 
+def test_extract_ucharmm():
+    reference = {
+        "n_atoms": 3341,
+        "Lx": 0,
+        "Ly": 0,
+        "Lz": 0,
+        "alpha": 0,
+        "beta": 0,
+        "gamma": 0,
+        "n_frames": 98,
+        "totaltime": 96.9999914562418,
+        "dt": 0.9999999119200186,
+    }
+    universe = mda.Universe(data.PSF, data.DCD)
+    
+    udata = info.extract(universe)
+    
+    for key in reference:
+        assert udata[key] == pytest.approx(reference[key])
+
+
+### Testing expected failure.
+def test_extract_non_universe():
+    universe = "This is not a universe."
+    with pytest.raises(AttributeError):
+        udata = info.extract(universe)
+
 ### testing with fixtures
 
 


### PR DESCRIPTION
@orbeckst Here are the additional tests for the pytest lesson.

Changes made in this Pull Request:
 - Added a non-fixture test for charmm data intended to be referenced for an exercise.
 - Added a test for an expected failure in the extract function.
